### PR TITLE
Cleanup

### DIFF
--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -65,34 +65,6 @@ DefPolicyPatch.x64=1
 DefPolicyOffset.x64=65BD7
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
 
-[6.0.6002.18005]
-SingleUserPatch.x86=1
-SingleUserOffset.x86=17FA8
-SingleUserCode.x86=nop
-SingleUserPatch.x64=1
-SingleUserOffset.x64=70FF6
-SingleUserCode.x64=Zero
-DefPolicyPatch.x86=1
-DefPolicyOffset.x86=179C0
-DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
-DefPolicyPatch.x64=1
-DefPolicyOffset.x64=65E83
-DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
-
-[6.0.6002.19214]
-SingleUserPatch.x86=1
-SingleUserOffset.x86=17FC4
-SingleUserCode.x86=nop
-SingleUserPatch.x64=1
-SingleUserOffset.x64=712AA
-SingleUserCode.x64=Zero
-DefPolicyPatch.x86=1
-DefPolicyOffset.x86=179B8
-DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
-DefPolicyPatch.x64=1
-DefPolicyOffset.x64=65FF7
-DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
-
 [6.0.6001.22286]
 SingleUserPatch.x86=1
 SingleUserOffset.x86=185E4
@@ -147,6 +119,34 @@ DefPolicyOffset.x86=18010
 DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=666AD
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6002.18005]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=17FA8
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=70FF6
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=179C0
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=65E83
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
+
+[6.0.6002.19214]
+SingleUserPatch.x86=1
+SingleUserOffset.x86=17FC4
+SingleUserCode.x86=nop
+SingleUserPatch.x64=1
+SingleUserOffset.x64=712AA
+SingleUserCode.x64=Zero
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=179B8
+DefPolicyCode.x86=CDefPolicy_Query_edx_ecx
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=65FF7
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx_jmp
 
 [6.0.6002.22515]
@@ -1722,7 +1722,6 @@ DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 SLInitHook.x86=1
 SLInitOffset.x86=45824
 SLInitFunc.x86=New_CSLQuery_Initialize
-
 
 [10.0.14393.2906]
 LocalOnlyPatch.x86=1
@@ -3525,28 +3524,28 @@ SLInitOffset.x64=1ABFC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.17763.288]
-Patch CEnforcementCore::GetInstanceOfTSLicense
+; Patch CEnforcementCore::GetInstanceOfTSLicense
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=AFAD4
 LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=77A11
 LocalOnlyCode.x64=jmpshort
-Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
+; Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
 SingleUserPatch.x86=1
 SingleUserOffset.x86=4D665
 SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=1322C
 SingleUserCode.x64=Zero
-Patch CDefPolicy::Query
+; Patch CDefPolicy::Query
 DefPolicyPatch.x86=1
 DefPolicyOffset.x86=4BE69
 DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17F45
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
-Hook CSLQuery::Initialize
+; Hook CSLQuery::Initialize
 SLInitHook.x86=1
 SLInitOffset.x86=5B18A
 SLInitFunc.x86=New_CSLQuery_Initialize
@@ -3555,24 +3554,28 @@ SLInitOffset.x64=1ABFC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.17763.292]
+; Patch CEnforcementCore::GetInstanceOfTSLicense
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=AFAD4
 LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=77A11
 LocalOnlyCode.x64=jmpshort
+; Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
 SingleUserPatch.x86=1
 SingleUserOffset.x86=4D665
 SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=1322C
 SingleUserCode.x64=Zero
+; Patch CDefPolicy::Query
 DefPolicyPatch.x86=1
 DefPolicyOffset.x86=4BE69
 DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=17F45
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+; Hook CSLQuery::Initialize
 SLInitHook.x86=1
 SLInitOffset.x86=5B18A
 SLInitFunc.x86=New_CSLQuery_Initialize
@@ -3607,27 +3610,59 @@ SLInitOffset.x64=1ABFC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.17763.437]
+; Patch CEnforcementCore::GetInstanceOfTSLicense
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=AFE24
 LocalOnlyCode.x86=jmpshort
 LocalOnlyPatch.x64=1
 LocalOnlyOffset.x64=77A41
 LocalOnlyCode.x64=jmpshort
+; Patch CSessionArbitrationHelper::IsSingleSessionPerUserEnabled
 SingleUserPatch.x86=1
 SingleUserOffset.x86=4D7B5
 SingleUserCode.x86=nop
 SingleUserPatch.x64=1
 SingleUserOffset.x64=1339C
 SingleUserCode.x64=Zero
+; Patch CDefPolicy::Query
 DefPolicyPatch.x86=1
 DefPolicyOffset.x86=4BFB9
 DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
 DefPolicyPatch.x64=1
 DefPolicyOffset.x64=18025
 DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+; Hook CSLQuery::Initialize
 SLInitHook.x86=1
 SLInitOffset.x86=5B2CA
 SLInitFunc.x86=New_CSLQuery_Initialize
+SLInitHook.x64=1
+SLInitOffset.x64=1ACDC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+
+[10.0.17763.771]
+LocalOnlyPatch.x86=1
+LocalOnlyOffset.x86=AFEB4
+LocalOnlyCode.x86=jmpshort
+SingleUserPatch.x86=1
+SingleUserOffset.x86=4D7F5
+SingleUserCode.x86=nop
+DefPolicyPatch.x86=1
+DefPolicyOffset.x86=4BFF9
+DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
+SLInitHook.x86=1
+SLInitOffset.x86=5B30A
+SLInitFunc.x86=New_CSLQuery_Initialize
+
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=77AD1
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1339C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=18025
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
 SLInitHook.x64=1
 SLInitOffset.x64=1ACDC
 SLInitFunc.x64=New_CSLQuery_Initialize
@@ -3708,6 +3743,20 @@ SLInitOffset.x86=5A77A
 SLInitFunc.x86=New_CSLQuery_Initialize
 SLInitHook.x64=1
 SLInitOffset.x64=22DDC
+SLInitFunc.x64=New_CSLQuery_Initialize
+
+[10.0.18908.1000]
+LocalOnlyPatch.x64=1
+LocalOnlyOffset.x64=879E4
+LocalOnlyCode.x64=jmpshort
+SingleUserPatch.x64=1
+SingleUserOffset.x64=1CC2C
+SingleUserCode.x64=Zero
+DefPolicyPatch.x64=1
+DefPolicyOffset.x64=24B35
+DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
+SLInitHook.x64=1
+SLInitOffset.x64=2853C
 SLInitFunc.x64=New_CSLQuery_Initialize
 
 [SLInit]
@@ -3948,7 +3997,6 @@ bServerSku.x64        =EDC04
 ulMaxDebugSessions.x64=EDC08
 bRemoteConnAllowed.x64=EDC0C
 
-
 [10.0.9926.0-SLInit]
 bFUSEnabled.x86       =C17D8
 lMaxUserSessions.x86  =C17DC
@@ -3997,7 +4045,6 @@ bServerSku.x86        =C3F74
 ulMaxDebugSessions.x86=C3F78
 bRemoteConnAllowed.x86=C3F7C
 
-zlMaxUserSessions.x64  =F23B0
 lMaxUserSessions.x64  =F23B0
 bAppServerAllowed.x64 =F23B4
 bServerSku.x64        =F23B8
@@ -5104,7 +5151,6 @@ bServerSku.x64        =E9484
 lMaxUserSessions.x64  =E9488
 bAppServerAllowed.x64 =E948C
 
-
 [10.0.16179.1000-SLInit]
 bInitialized.x86      =C7F6C
 bServerSku.x86        =C7F70
@@ -5504,8 +5550,6 @@ bMultimonAllowed.x64  =EE4A8
 ulMaxDebugSessions.x64=EE4AC
 bFUSEnabled.x64       =EE4B0
 
-
-
 [10.0.16299.1087-SLInit]
 bInitialized.x86      =C6F7C
 bServerSku.x86        =C6F80
@@ -5831,23 +5875,23 @@ ulMaxDebugSessions.x64=ECACC
 bFUSEnabled.x64       =ECAD0
 
 [10.0.17763.288-SLInit]
-bInitialized.x86 =CD798
-bServerSku.x86 =CD79C
-lMaxUserSessions.x86 =CD7A0
+bInitialized.x86      =CD798
+bServerSku.x86        =CD79C
+lMaxUserSessions.x86  =CD7A0
 bAppServerAllowed.x86 =CD7A8
 bRemoteConnAllowed.x86=CD7AC
-bMultimonAllowed.x86 =CD7B0
+bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
-bFUSEnabled.x86 =CD7B8
+bFUSEnabled.x86       =CD7B8
 
-bInitialized.x64 =ECAB0
-bServerSku.x64 =ECAB4
-lMaxUserSessions.x64 =ECAB8
+bInitialized.x64      =ECAB0
+bServerSku.x64        =ECAB4
+lMaxUserSessions.x64  =ECAB8
 bAppServerAllowed.x64 =ECAC0
 bRemoteConnAllowed.x64=ECAC4
-bMultimonAllowed.x64 =ECAC8
+bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
-bFUSEnabled.x64 =ECAD0
+bFUSEnabled.x64       =ECAD0
 
 [10.0.17763.292-SLInit]
 bInitialized.x86      =CD798
@@ -5858,8 +5902,8 @@ bRemoteConnAllowed.x86=CD7AC
 bMultimonAllowed.x86  =CD7B0
 ulMaxDebugSessions.x86=CD7B4
 bFUSEnabled.x86       =CD7B8
-bInitialized.x64      =ECAB0
 
+bInitialized.x64      =ECAB0
 bServerSku.x64        =ECAB4
 lMaxUserSessions.x64  =ECAB8
 bAppServerAllowed.x64 =ECAC0
@@ -5905,33 +5949,6 @@ bRemoteConnAllowed.x64=ECAC4
 bMultimonAllowed.x64  =ECAC8
 ulMaxDebugSessions.x64=ECACC
 bFUSEnabled.x64       =ECAD0
-
-[10.0.17763.771]
-LocalOnlyPatch.x86=1
-LocalOnlyOffset.x86=AFEB4
-LocalOnlyCode.x86=jmpshort
-SingleUserPatch.x86=1
-SingleUserOffset.x86=4D7F5
-SingleUserCode.x86=nop
-DefPolicyPatch.x86=1
-DefPolicyOffset.x86=4BFF9
-DefPolicyCode.x86=CDefPolicy_Query_eax_ecx
-SLInitHook.x86=1
-SLInitOffset.x86=5B30A
-SLInitFunc.x86=New_CSLQuery_Initialize
-
-LocalOnlyPatch.x64=1
-LocalOnlyOffset.x64=77AD1
-LocalOnlyCode.x64=jmpshort
-SingleUserPatch.x64=1
-SingleUserOffset.x64=1339C
-SingleUserCode.x64=Zero
-DefPolicyPatch.x64=1
-DefPolicyOffset.x64=18025
-DefPolicyCode.x64=CDefPolicy_Query_eax_rcx
-SLInitHook.x64=1
-SLInitOffset.x64=1ACDC
-SLInitFunc.x64=New_CSLQuery_Initialize
 
 [10.0.17763.771-SLInit]
 bInitialized.x86      =CD798
@@ -5989,6 +6006,16 @@ bRemoteConnAllowed.x64=F6AA0
 bMultimonAllowed.x64  =F6AA4
 ulMaxDebugSessions.x64=F6AA8
 bFUSEnabled.x64       =F6AAC
+
+[10.0.18908.1000-SLInit]
+bInitialized.x64      =FFD58
+bServerSku.x64        =FFD5C
+lMaxUserSessions.x64  =FFD60
+bAppServerAllowed.x64 =FFD68
+bRemoteConnAllowed.x64=FFD6C
+bMultimonAllowed.x64  =FFD70
+ulMaxDebugSessions.x64=FFD74
+bFUSEnabled.x64       =FFD78
 
 [10.0.18362.267-SLInit]
 bInitialized.x86      =D577C

--- a/res/rdpwrap.ini
+++ b/res/rdpwrap.ini
@@ -3639,7 +3639,6 @@ SLInitHook.x64=1
 SLInitOffset.x64=1ACDC
 SLInitFunc.x64=New_CSLQuery_Initialize
 
-
 [10.0.17763.771]
 LocalOnlyPatch.x86=1
 LocalOnlyOffset.x86=AFEB4


### PR DESCRIPTION
### description
This the `rdpwrap.ini` that I personally use, with cleaned up syntax and one missing build from [your one](https://github.com/stascorp/rdpwrap/pull/922)

### added missing builds
- `[10.0.18908.1000]`

### cleanup
- `6.0.6002.xxxx` should comes after `6.0.6001.xxxx` builds, not before
- comments under `10.0.17763.288` entry are missing the **`;`** semicolon
- removed some unnecessary new lines, added some spaces to fix padding
- the `zlMaxUserSessions` parameter is bogus and should be removed (under `10.0.9926.0-SLInit` entry)
- the `10.0.17763.771` entry is moved above the `-SLInit` entries
